### PR TITLE
en, zh: address version support

### DIFF
--- a/en/feature-overview.md
+++ b/en/feature-overview.md
@@ -10,8 +10,8 @@ This document describes the data replication features provided by the Data Migra
 
 For different DM versions, pay attention to the different match rules of schema or table names in the table routing, black & white lists, and binlog event filter features:
 
-+ For DM v1.0.4 or later versions, all the above features support the [wildcard match](https://en.wikipedia.org/wiki/Glob_(programming)#Syntax). For all versions of DM, note that there can be **only one** `*` in the wildcard expression, and `*` **must be placed at the end**.
-+ For DM versions earlier than v1.0.4, table routing and binlog event filter support the wildcard but do not support the `[...]` and `[!...]` expressions. The black & white lists only supports the regular expression.
++ For DM v1.0.5 or later versions, all the above features support the [wildcard match](https://en.wikipedia.org/wiki/Glob_(programming)#Syntax). For all versions of DM, note that there can be **only one** `*` in the wildcard expression, and `*` **must be placed at the end**.
++ For DM versions earlier than v1.0.5, table routing and binlog event filter support the wildcard but do not support the `[...]` and `[!...]` expressions. The black & white lists only supports the regular expression.
 
 It is recommended that you use the wildcard for matching in simple scenarios.
 
@@ -110,7 +110,7 @@ The black and white lists filtering rule of the upstream database instance table
 black-white-list:
   rule-1:
     do-dbs: ["test*"]         # Starting with characters other than "~" indicates that it is a wildcard;
-                              # v1.0.4 or later versions support the regular expression rules.
+                              # v1.0.5 or later versions support the regular expression rules.
 ​    do-tables:
     - db-name: "test[123]"    # Matches test1, test2, and test3.
       tbl-name: "t[1-5]"      # Matches t1, t2, t3, t4, and t5.

--- a/zh/feature-overview.md
+++ b/zh/feature-overview.md
@@ -120,7 +120,7 @@ routes:
 ```yaml
 black-white-list:
   rule-1:
-    do-dbs: ["test*"]         # 非 ~ 字符开头，表示规则是通配符；v1.0.4 及后续版本支持通配符规则。
+    do-dbs: ["test*"]         # 非 ~ 字符开头，表示规则是通配符；v1.0.5 及后续版本支持通配符规则。
 ​    do-tables:
     - db-name: "test[123]"    # 匹配 test1、test2、test3。
       tbl-name: "t[1-5]"      # 匹配 t1、t2、t3、t4、t5。

--- a/zh/feature-overview.md
+++ b/zh/feature-overview.md
@@ -10,8 +10,8 @@ category: reference
 
 Table Routing、Black & White Lists、Binlog Event Filter 在匹配库表名时，有以下版本差异：
 
-+ 对于 v1.0.4 版及后续版本，以上功能均支持[通配符匹配](https://en.wikipedia.org/wiki/Glob_(programming)#Syntax)。但注意所有版本中通配符匹配中的 `*` 符号 **只能有一个且必须在末尾**。
-+ 对于 v1.0.4 以前的版本，Table Routing 和 Binlog Event Filter 支持通配符，但不支持 `[...]` 与 `[!...]` 表达式。Black & White Lists 仅支持正则表达式。
++ 对于 v1.0.5 版及后续版本，以上功能均支持[通配符匹配](https://en.wikipedia.org/wiki/Glob_(programming)#Syntax)。但注意所有版本中通配符匹配中的 `*` 符号 **只能有一个且必须在末尾**。
++ 对于 v1.0.5 以前的版本，Table Routing 和 Binlog Event Filter 支持通配符，但不支持 `[...]` 与 `[!...]` 表达式。Black & White Lists 仅支持正则表达式。
 
 在简单任务场景下推荐使用通配符匹配。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->
Fix version for black-white list.

### Which TiDB Data Migration (DM) version(s) do your changes apply to? (Required)
In https://github.com/pingcap/docs-cn/pull/2383 we set support wildcard version to v1.0.4. Actually it's v1.0.5.

<!--Tick the checkbox(es) below to choose the DM version(s) that your changes apply to.-->

- [x] master (the latest development version, including v2.0 changes for now)
- [x] v1.0 (TiDB DM 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.0** and **needs-cherry-pick-2.0**.-->

### What is the related PR or file link(s)?
https://github.com/pingcap/dm/pull/515 only update the master branch but isn't cherry-picked to release-1.0. Actually this is supported from v1.0.5.
https://github.com/pingcap/dm/pull/632
<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
