### PR TITLE
zh: frame special characters with quotes to ensure encryption correctness

### DIFF
--- a/zh/deploy-a-dm-cluster-using-ansible.md
+++ b/zh/deploy-a-dm-cluster-using-ansible.md
@@ -370,7 +370,7 @@ cd /home/tidb/dm-ansible/resources/bin &&
 ```
 
 ```
-Hp/97+nW/hnsdHwFbPrAwUCjxII7JqOEMo3J7Wk0
+MKxn0Qo3m3XOyjCnhEMtsUCm83EhGQDZ/T4=
 ```
 
 ## 第 8 步：编辑 `inventory.ini` 文件中的变量

--- a/zh/deploy-a-dm-cluster-using-ansible.md
+++ b/zh/deploy-a-dm-cluster-using-ansible.md
@@ -366,11 +366,11 @@ grafana_admin_password = "admin"
 
 ```bash
 cd /home/tidb/dm-ansible/resources/bin &&
-./dmctl -encrypt 123456
+./dmctl -encrypt 'abc!@#123'
 ```
 
 ```
-VjX8cEeTX+qcvZ3bPaO4h0C80pe/1aU=
+Hp/97+nW/hnsdHwFbPrAwUCjxII7JqOEMo3J7Wk0
 ```
 
 ## 第 8 步：编辑 `inventory.ini` 文件中的变量


### PR DESCRIPTION
https://asktug.com/t/topic/35036
已经复现。
密码形式为：abc(字符)@(特殊字符)123(数字)
如果不加引号加密，task 将会报错。

"msg": "[code=10001:class=dump-unit:scope=upstream:level=high] fail to initial unit Dump of subtask qh : database driver error: Error 1045: Access denied for user 'qh_test'@'172.16.5.169' (using password: YES)\n

<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB Data Migration (DM) version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the DM version(s) that your changes apply to.-->

- [x] master (the latest development version, including v2.0 changes for now)
- [x] v1.0 (TiDB DM 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.0** and **needs-cherry-pick-2.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
