### PR TITLE
zh: add `clean-dump-file` configuration (release-1.0)

### DIFF
--- a/zh/task-configuration-file-full.md
+++ b/zh/task-configuration-file-full.md
@@ -30,6 +30,7 @@ remove-meta: false              # 是否在任务同步开始前移除该任务�
 enable-heartbeat: false         # 是否开启 `heartbeat` 功能
 online-ddl-scheme: "gh-ost"     # 目前仅支持 "gh-ost" 、"pt"
 case-sensitive: false           # schema/table 是否大小写敏感
+clean-dump-file: true           # 是否清理 dump 阶段产生的文件，包括 metadata 文件、建库建表 SQL 文件以及数据导入 SQL 文件
 
 target-database:                # 下游数据库实例配置
   host: "192.168.0.1"

--- a/zh/task-configuration-file-full.md
+++ b/zh/task-configuration-file-full.md
@@ -30,7 +30,7 @@ remove-meta: false              # 是否在任务同步开始前移除该任务�
 enable-heartbeat: false         # 是否开启 `heartbeat` 功能
 online-ddl-scheme: "gh-ost"     # 目前仅支持 "gh-ost" 、"pt"
 case-sensitive: false           # schema/table 是否大小写敏感
-clean-dump-file: true           # 是否清理 dump 阶段产生的文件，包括 metadata 文件、建库建表 SQL 文件以及数据导入 SQL 文件
+clean-dump-file: true           # 是否清理 dump 阶段产生的文件，包括 metadata 文件、建库建表 SQL 文件以及数据导入 SQL 文件。v1.0.7 新增
 
 target-database:                # 下游数据库实例配置
   host: "192.168.0.1"


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
add configuration introduced by https://github.com/pingcap/dm/pull/804

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version, including v2.0 changes for now)
- [x] v1.0 (TiDB DM 1.0 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
**If you select two versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add the label **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
  https://github.com/pingcap/dm/pull/804