### PR TITLE
zh, en: remove improper guide

### DIFF
--- a/en/migrate-from-mysql-aurora.md
+++ b/en/migrate-from-mysql-aurora.md
@@ -183,7 +183,7 @@ When the data sources are successfully added, the return information of each dat
 
 > **Note:**
 >
-> Because Aurora does not support FTWRL, write operations have to be paused when you only perform the full data migration to export data. See [AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/?nc1=h_ls) for details. In this example, both full data migration and incremental replication are performed, and DM automatically enables the `safe mode` to solve this pause issue, but data inconsistency might still occur. To ensure data consistency, see [AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/?nc1=h_ls), and set the last line `extra-args` in the following configuration file to empty.
+> Because Aurora does not support FTWRL, write operations have to be paused when you only perform the full data migration to export data. See [AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/?nc1=h_ls) for details. In this example, both full data migration and incremental replication are performed, and DM automatically enables the `safe mode` to solve this pause issue, but data inconsistency might still occur. To ensure data consistency, see [AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/?nc1=h_ls).
 
 This example migrates the existing data in Aurora and replicates incremental data to TiDB in real time, which is the **full data migration plus incremental replication** mode. According to the TiDB cluster information above, the added `source-id`, and the table to be migrated, save the following task configuration file `task.yaml`:
 
@@ -217,7 +217,7 @@ block-allow-list:
 
 # The configuration of the dump unit.
 mydumpers:
-   global:                             # Quoted by mydumper-config-name: "global" above
+   global:                            # Quoted by mydumper-config-name: "global" above
     extra-args: "--consistency none"  # Aurora does not support FTWRL, you need to configure this option to bypass FTWRL.
 ```
 

--- a/zh/migrate-from-mysql-aurora.md
+++ b/zh/migrate-from-mysql-aurora.md
@@ -187,7 +187,7 @@ tiup dmctl --master-addr 127.0.0.1:8261 operate-source create dm-test/source2.ya
 
 > **注意：**
 >
-> 由于 Aurora 不支持 FTWRL，仅使用全量模式导出数据时需要暂停写入，参见 [AWS 官网说明](https://aws.amazon.com/cn/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/)。在示例的全量+增量模式下，DM 将自动启用 `safe mode` 解决这一问题，但仍有可能出现数据不一致。如需保证数据一致，参见 [AWS 官网说明](https://aws.amazon.com/cn/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/)操作，并将下文的配置文件最后一行 `extra-args` 设置为空。
+> 由于 Aurora 不支持 FTWRL，仅使用全量模式导出数据时需要暂停写入，参见 [AWS 官网说明](https://aws.amazon.com/cn/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/)。在示例的全量+增量模式下，DM 将自动启用 `safe mode` 解决这一问题，但仍有可能出现数据不一致。如需保证数据一致，参见 [AWS 官网说明](https://aws.amazon.com/cn/premiumsupport/knowledge-center/mysqldump-error-rds-mysql-mariadb/)操作。
 
 本示例选择迁移 Aurora 已有数据并将新增数据实时迁移给 TiDB，即**全量+增量**模式。根据上文的 TiDB 集群信息、已添加的 `source-id`、要迁移的表，保存如下任务配置文件 `task.yaml`：
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

removed wrong guide because other consistency than `--consistency none` is always unabled.

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version, including v3.0 changes)
- [x] v2.0 (TiDB DM 2.0 versions)
- [ ] v1.0 (TiDB DM 1.0 versions)

<!-- For contributors:
**If you select two versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add the label **needs-cherry-pick-2.0** or **needs-cherry-pick-1.0**. If you don't have write access to this repo, leave a comment to the PR that says "label <label_1>[,<label_2>]". It tells the bot to help add the labels.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts after cherry-picked
