### PR TITLE
chore: remove copyable code snippet when generate PDF

### DIFF
--- a/scripts/merge_by_toc.py
+++ b/scripts/merge_by_toc.py
@@ -23,6 +23,8 @@ image_link_pattern = re.compile(r'!\[(.*?)\]\((.*?)\)')
 level_pattern = re.compile(r'(\s*[\-\+]+)\s')
 # match all headings
 heading_patthern = re.compile(r'(^#+|\n#+)\s')
+# match copyable snippet code
+copyable_snippet_pattern = re.compile(r'{{< copyable .* >}}')
 
 entry_file = lang + "TOC.md"
 
@@ -126,14 +128,9 @@ def replace_heading_func(diff_level=0):
 
     return replace_heading
 
-def replace_img_link(match):
-    full = match.group(0)
-    link_name = match.group(1)
-    link = match.group(2)
-
-    if link.endswith('.png'):
-        fname = os.path.basename(link)
-        return '![%s](./media/%s)' % (link_name, fname)
+# remove copyable snippet code
+def remove_copyable(match):
+    return ''
 
 # stage 3, concat files
 for type_, level, name in followups:
@@ -146,7 +143,7 @@ for type_, level, name in followups:
             with open(lang + name) as fp:
                 chapter = fp.read()
                 chapter = replace_link_wrap(chapter, name)
-                # chapter = image_link_pattern.sub(replace_img_link, chapter)
+                chapter = copyable_snippet_pattern.sub(remove_copyable, chapter)
 
                 # fix heading level
                 diff_level = level - heading_patthern.findall(chapter)[0].count('#')


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which DM version(s) do your changes apply to? (Required)
Remove `copyable` code snippet when generate PDF.
<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version, including v3.0 changes)
- [x] v2.0 (TiDB DM 2.0 versions)
- [x] v1.0 (TiDB DM 1.0 versions)

<!-- For contributors:
**If you select two versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add the label **needs-cherry-pick-2.0** or **needs-cherry-pick-1.0**. If you don't have write access to this repo, leave a comment to the PR that says "label <label_1>[,<label_2>]". It tells the bot to help add the labels.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts after cherry-picked
