### PR TITLE
zh,en: change `sql` to `DDL` for handle-error command

### DIFF
--- a/en/TOC.md
+++ b/en/TOC.md
@@ -44,7 +44,7 @@
     - [Pause a Task](pause-task.md)
     - [Resume a Task](resume-task.md)
     - [Stop a Task](stop-task.md)
-    - [Handle Failed SQL Statements](handle-failed-sql-statements.md)
+    - [Handle Failed DDL Statements](handle-failed-ddl-statements.md)
   - [Manually Handle Sharding DDL Locks](manually-handling-sharding-ddl-locks.md)
   - [Manage Table Schema during Migration](manage-schema.md)
   - [Handle Alerts](handle-alerts.md)

--- a/en/_index.md
+++ b/en/_index.md
@@ -12,7 +12,7 @@ aliases: ['/docs/tidb-data-migration/dev/']
 
 - [High availability of data migration tasks](overview.md#high-availability). The data migration task can run normally even when some DM-master or DM-worker nodes fail.
 - [Sharding DDL support in the optimistic mode](feature-shard-merge-optimistic.md). In this mode, migration latency can be reduced in some scenarios and you can make A/B changes in the upstream database.
-- Better usability, including the new [error handling mechanism](handle-failed-sql-statements.md) and the easier-to-read error messages and error handling suggestions.
+- Better usability, including the new [error handling mechanism](handle-failed-ddl-statements.md) and the easier-to-read error messages and error handling suggestions.
 - [TLS support](enable-tls.md) for connections between the upstream and the downstream, and for connections between DM components.
 - Support for migrating data from MySQL 8.0 (experimental).
 

--- a/en/faq.md
+++ b/en/faq.md
@@ -22,7 +22,7 @@ DM will attempt to split a single statement containing multiple DDL change opera
 
 ## How to handle incompatible DDL statements?
 
-When you encounter a DDL statement unsupported by TiDB, you need to manually handle it using dmctl (skipping the DDL statement or replacing the DDL statement with a specified DDL statement). For details, see [Handle failed SQL statements](handle-failed-sql-statements.md).
+When you encounter a DDL statement unsupported by TiDB, you need to manually handle it using dmctl (skipping the DDL statement or replacing the DDL statement with a specified DDL statement). For details, see [Handle failed DDL statements](handle-failed-ddl-statements.md).
 
 > **Note:**
 >

--- a/en/handle-failed-ddl-statements.md
+++ b/en/handle-failed-ddl-statements.md
@@ -1,41 +1,41 @@
 ---
-title: 处理出错的 SQL 语句
-summary: 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 SQL 语句。
-aliases: ['/docs-cn/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/','/zh/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements']
+title: Handle Failed DDL Statements
+summary: Learn how to handle failed DDL statements when you're using the TiDB Data Migration tool to migrate data.
+aliases: ['/docs/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/','/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements','/tidb-data-migration/dev/handle-failed-sql-statements']
 ---
 
-# 处理出错的 SQL 语句
+# Handle Failed DDL Statements
 
-本文介绍了如何使用 DM 来处理出错的 SQL 语句。
+This document introduces how to handle failed DDL statements when you're using the TiDB Data Migration (DM) tool to migrate data.
 
-目前，TiDB 并不完全兼容所有的 MySQL 语法（详见 [TiDB 已支持的 DDL 语句](https://pingcap.com/docs-cn/dev/reference/mysql-compatibility/#ddl)）。当使用 DM 从 MySQL 迁移数据到 TiDB 时，如果 TiDB 不支持对应的 SQL 语句，可能会造成错误并中断迁移任务。在这种情况下，DM 提供 `handle-error` 命令来恢复迁移。
+Currently, TiDB is not completely compatible with all MySQL syntax (see [the DDL statements supported by TiDB](https://pingcap.com/docs/dev/reference/mysql-compatibility/#ddl)). Therefore, when DM is migrating data from MySQL to TiDB and TiDB does not support the corresponding DDL statement, an error might occur and break the migration process. In this case, you can use the `handle-error` command of DM to resume the migration.
 
-## 使用限制
+## Restrictions
 
-如果业务不能接受下游 TiDB 跳过异常的 DDL 语句，也不接受使用其他 DDL 语句作为替代，则不适合使用此方式进行处理。
+If it is unacceptable in the actual production environment that the failed DDL statement is skipped in the downstream TiDB and it cannot be replaced with other DDL statements, then do not use this command.
 
-比如：`DROP PRIMARY KEY`，这种情况下，只能在下游重建一个（DDL 执行完后的）新表结构对应的表，并将原表的全部数据重新导入该新表。
+For example, `DROP PRIMARY KEY`. In this scenario, you can only create a new table in the downstream with the new table schema (after executing the DDL statement), and re-import all the data into this new table.
 
-## 支持场景
+## Supported scenarios
 
-迁移过程中，上游执行了 TiDB 不支持的 DDL 语句并迁移到了 DM，造成迁移任务中断。
+During the migration, the DDL statement unsupported by TiDB is executed in the upstream and migrated to the downstream, and as a result, the migration task gets interrupted.
 
-- 如果业务能接受下游 TiDB 不执行该 DDL 语句，则使用 `handle-error <task-name> skip` 跳过对该 DDL 语句的迁移以恢复迁移任务。
-- 如果业务能接受下游 TiDB 执行其他 DDL 语句来作为替代，则使用 `handle-error <task-name> replace` 替代该 DDL 的迁移以恢复迁移任务。
+- If it is acceptable that this DDL statement is skipped in the downstream TiDB, then you can use `handle-error <task-name> skip` to skip migrating this DDL statement and resume the migration.
+- If it is acceptable that this DDL statement is replaced with other DDL statements, then you can use `handle-error <task-name> replace` to replace this DDL statement and resume the migration.
 
-## 命令介绍
+## Command
 
-使用 dmctl 手动处理出错的 SQL 语句时，主要使用的命令包括 `query-status`、`handle-error`。
+When you use dmctl to manually handle the failed DDL statements, the commonly used commands include `query-status` and `handle-error`.
 
 ### query-status
 
-`query-status` 命令用于查询当前 MySQL 实例内子任务及 relay 单元等的状态和错误信息，详见[查询状态](query-status.md)。
+The `query-status` command is used to query the current status of items such as the subtask and the relay unit in each MySQL instance. For details, see [query status](query-status.md).
 
 ### handle-error
 
-`handle-error` 命令用于处理错误的 sql 语句。
+The `handle-error` command is used to handle the failed DDL statements.
 
-### 命令用法
+### Command usage
 
 ```bash
 » handle-error -h
@@ -53,35 +53,35 @@ Global Flags:
   -s, --source strings   MySQL Source ID
 ```
 
-### 参数解释
+### Flags descriptions
 
-+ `task-name`：
-    - 非 flag 参数，string，必选；
-    - 指定预设的操作将生效的任务。
++ `task-name`:
+    - Non-flag parameter, string, required
+    - `task-name` specifies the name of the task in which the presetted operation is going to be executed.
 
-+ `source`：
-    - flag 参数，string，`--source`；
-    - `source` 指定预设操作将生效的 MySQL 实例。
++ `source`:
+    - Flag parameter, string, `--source`
+    - `source` specifies the MySQL instance in which the preset operation is to be executed.
 
-+ `skip`：跳过该错误
++ `skip`: Skip the error
 
-+ `replace`：替代错误的 DDL 语句
++ `replace`: Replace the failed DDL statement
 
-+ `revert`：重置该错误先前的 skip/replace 操作, 仅在先前的操作没有最终生效前执行
++ `revert`: Reset the previous skip/replace operation before the error occurs (only reset it when the previous skip/replace operation has not finally taken effect)
 
-+ `binlog-pos`：
-    - flag 参数，string，`--binlog-pos`；
-    - 若不指定，DM 会自动处理当前出错的 SQL 语句
-    - 在指定时表示操作将在 `binlog-pos` 与 binlog event 的 position 匹配时生效，格式为 `binlog-filename:binlog-pos`，如 `mysql-bin|000001.000003:3270`。
-    - 在迁移执行出错后，binlog position 可直接从 `query-status` 返回的 `startLocation` 中的 `position` 获得；在迁移执行出错前，binlog position 可在上游 MySQL 中使用 [`SHOW BINLOG EVENTS`](https://dev.mysql.com/doc/refman/5.7/en/show-binlog-events.html) 获得。
++ `binlog-pos`:
+    - Flag parameter, string, `--binlog-pos`
+    - If it is not specified, DM automatically handles the currently failed DDL statement.
+    - If it is specified, the skip operation is executed when `binlog-pos` matches with the position of the binlog event. The format is `binlog-filename:binlog-pos`, for example, `mysql-bin|000001.000003:3270`.
+    - After the migration returns an error, the binlog position can be obtained from `position` in `startLocation` returned by `query-status`. Before the migration returns an error, the binlog position can be obtained by using [`SHOW BINLOG EVENTS`](https://dev.mysql.com/doc/refman/5.7/en/show-binlog-events.html) in the upstream MySQL instance.
 
-## 使用示例
+## Usage examples
 
-### 迁移中断执行跳过操作
+### Skip DDL if the migration gets interrupted
 
-#### 非合库合表场景
+#### Non-shard-merge scenario
 
-假设现在需要将上游的 `db1.tbl1` 表迁移到下游 TiDB，初始时表结构为：
+Assume that you need to migrate the upstream table `db1.tbl1` to the downstream TiDB. The initial table schema is:
 
 {{< copyable "sql" >}}
 
@@ -89,7 +89,7 @@ Global Flags:
 SHOW CREATE TABLE db1.tbl1;
 ```
 
-```
+```sql
 +-------+--------------------------------------------------+
 | Table | Create Table                                     |
 +-------+--------------------------------------------------+
@@ -101,7 +101,7 @@ SHOW CREATE TABLE db1.tbl1;
 +-------+--------------------------------------------------+
 ```
 
-此时，上游执行以下 DDL 操作修改表结构（将列的 DECIMAL(11, 3) 修改为 DECIMAL(10, 3)）：
+Now, the following DDL statement is executed in the upstream to alter the table schema (namely, alter DECIMAL(11, 3) of c2 into DECIMAL(10, 3)):
 
 {{< copyable "sql" >}}
 
@@ -109,15 +109,15 @@ SHOW CREATE TABLE db1.tbl1;
 ALTER TABLE db1.tbl1 CHANGE c2 c2 DECIMAL (10, 3);
 ```
 
-则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status <task-name>` 命令可看到如下错误：
+Because this DDL statement is not supported by TiDB, the migration task of DM gets interrupted. Execute the `query-status <task-name>` command, and you can see the following error:
 
 ```
 ERROR 8200 (HY000): Unsupported modify column: can't change decimal column precision
 ```
 
-假设业务上可以接受下游 TiDB 不执行此 DDL 语句（即继续保持原有的表结构），则可以通过使用 `handle-error <task-name> skip` 命令跳过该 DDL 语句以恢复迁移任务。操作步骤如下：
+Assume that it is acceptable in the actual production environment that this DDL statement is not executed in the downstream TiDB (namely, the original table schema is retained). Then you can use `handle-error <task-name> skip` to skip this DDL statement to resume the migration. The procedures are as follows:
 
-1. 使用 `handle-error <task-name> skip` 跳过当前错误的 DDL 语句
+1. Execute `handle-error <task-name> skip` to skip the currently failed DDL statement:
 
     {{< copyable "" >}}
 
@@ -140,7 +140,7 @@ ERROR 8200 (HY000): Unsupported modify column: can't change decimal column preci
     }
     ```
 
-2. 使用 `query-status <task-name>` 查看任务状态
+2. Execute `query-status <task-name>` to view the task status:
 
     {{< copyable "" >}}
 
@@ -148,7 +148,7 @@ ERROR 8200 (HY000): Unsupported modify column: can't change decimal column preci
     » query-status test
     ```
 
-    <details><summary> 执行结果 </summary>
+    <details><summary> See the execution result.</summary>
 
     ```
     {
@@ -195,16 +195,16 @@ ERROR 8200 (HY000): Unsupported modify column: can't change decimal column preci
 
     </details>
 
-    可以看到任务运行正常，错误的 DDL 被跳过。
+    You can see that the task runs normally and the wrong DDL is skipped.
 
-#### 合库合表场景
+#### Shard merge scenario
 
-假设现在存在如下四个上游表需要合并迁移到下游的同一个表 ``` `shard_db`.`shard_table` ```，任务模式为悲观协调模式：
+Assume that you need to merge and migrate the following four tables in the upstream to one same table ``` `shard_db`.`shard_table` ``` in the downstream. The task mode is "pessimistic".
 
-- MySQL 实例 1 内有 `shard_db_1` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
-- MySQL 实例 2 内有 `shard_db_2` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
+- MySQL instance 1 contains the `shard_db_1` schema, which includes the `shard_table_1` and `shard_table_2` tables.
+- MySQL instance 2 contains the `shard_db_2` schema, which includes the `shard_table_1` and `shard_table_2` tables.
 
-初始时表结构为：
+The initial table schema is:
 
 {{< copyable "sql" >}}
 
@@ -212,7 +212,7 @@ ERROR 8200 (HY000): Unsupported modify column: can't change decimal column preci
 SHOW CREATE TABLE shard_db.shard_table;
 ```
 
-```
+```sql
 +-------+-----------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                              |
 +-------+-----------------------------------------------------------------------------------------------------------+
@@ -223,7 +223,7 @@ SHOW CREATE TABLE shard_db.shard_table;
 +-------+-----------------------------------------------------------------------------------------------------------+
 ```
 
-此时，在上游所有分表上都执行以下 DDL 操作修改表字符集
+Now, execute the following DDL statement to all upstream sharded tables to alter their character set:
 
 {{< copyable "sql" >}}
 
@@ -231,7 +231,7 @@ SHOW CREATE TABLE shard_db.shard_table;
 ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DANISH_CI;
 ```
 
-则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status` 命令可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_1` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_1` 表报错：
+Because this DDL statement is not supported by TiDB, the migration task of DM gets interrupted. Execute the `query-status` command, and you can see the following errors reported by the `shard_db_1`.`shard_table_1` table in MySQL instance 1 and the `shard_db_2`.`shard_table_1` table in MySQL instance 2:
 
 ```
 {
@@ -247,9 +247,9 @@ ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DAN
 }
 ```
 
-假设业务上可以接受下游 TiDB 不执行此 DDL 语句（即继续保持原有的表结构），则可以通过使用 `handle-error <task-name> skip` 命令跳过该 DDL 语句以恢复迁移任务。操作步骤如下：
+Assume that it is acceptable in the actual production environment that this DDL statement is not executed in the downstream TiDB (namely, the original table schema is retained). Then you can use `handle-error <task-name> skip` to skip this DDL statement to resume the migration. The procedures are as follows:
 
-1. 使用 `handle-error <task-name> skip` 跳过 MySQL 实例 1 和实例 2 当前错误的 DDL 语句
+1. Execute `handle-error <task-name> skip` to skip the currently failed DDL statements in MySQL instance 1 and 2:
 
     {{< copyable "" >}}
 
@@ -278,7 +278,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DAN
     }
     ```
 
-2. 使用 `query-status <task-name>` 查看任务状态，可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_2` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_2` 表报错：
+2. Execute the `query-status` command, and you can see the errors reported by the `shard_db_1`.`shard_table_2` table in MySQL instance 1 and the `shard_db_2`.`shard_table_2` table in MySQL instance 2:
 
     ```
     {
@@ -294,7 +294,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DAN
     }
     ```
 
-3. 继续使用 `handle-error <task-name> skip` 跳过 MySQL 实例 1 和实例 2 当前错误的 DDL 语句
+3. Execute `handle-error <task-name> skip` again to skip the currently failed DDL statements in MySQL instance 1 and 2:
 
     {{< copyable "" >}}
 
@@ -323,7 +323,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DAN
     }
     ```
 
-4. 使用 `query-status <task-name>` 查看任务状态
+4. Use `query-status <task-name>` to view the task status:
 
     {{< copyable "" >}}
 
@@ -331,7 +331,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DAN
     » query-status test
     ```
 
-    <details><summary> 执行结果 </summary>
+    <details><summary> See the execution result.</summary>
 
     ```
     {
@@ -412,13 +412,13 @@ ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DAN
 
     </details>
 
-    可以看到任务运行正常，无错误信息。四条 DDL 全部被跳过。
+    You can see that the task runs normally with no error and all four wrong DDL statements are skipped.
 
-### 迁移中断执行替代操作
+### Replace DDL if the migration gets interrupted
 
-#### 非合库合表场景
+#### Non-shard-merge scenario
 
-假设现在需要将上游的 `db1.tbl1` 表迁移到下游 TiDB，初始时表结构为：
+Assume that you need to migrate the upstream table `db1.tbl1` to the downstream TiDB. The initial table schema is:
 
 {{< copyable "sql" >}}
 
@@ -426,7 +426,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DAN
 SHOW CREATE TABLE db1.tbl1;
 ```
 
-```
+```SQL
 +-------+-----------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                              |
 +-------+-----------------------------------------------------------------------------------------------------------+
@@ -437,7 +437,7 @@ SHOW CREATE TABLE db1.tbl1;
 +-------+-----------------------------------------------------------------------------------------------------------+
 ```
 
-此时，上游执行以下 DDL 操作增加新列，并添加 UNIQUE 约束
+Now, perform the following DDL operation in the upstream to add a new column with the UNIQUE constraint:
 
 {{< copyable "sql" >}}
 
@@ -445,7 +445,7 @@ SHOW CREATE TABLE db1.tbl1;
 ALTER TABLE `db1`.`tbl1` ADD COLUMN new_col INT UNIQUE;
 ```
 
-则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status` 命令可看到如下错误：
+Because this DDL statement is not supported by TiDB, the migration task gets interrupted. Execute the `query-status` command, and you can see the following error:
 
 ```
 {
@@ -454,9 +454,9 @@ ALTER TABLE `db1`.`tbl1` ADD COLUMN new_col INT UNIQUE;
 }
 ```
 
-我们将该 DDL 替换成两条等价的 DDL。操作步骤如下：
+You can replace this DDL statement with two equivalent DDL statements. The steps are as follows:
 
-1. 使用如下命令替换错误的 DDL 语句
+1. Replace the wrong DDL statement by the following command:
 
     {{< copyable "" >}}
 
@@ -479,7 +479,7 @@ ALTER TABLE `db1`.`tbl1` ADD COLUMN new_col INT UNIQUE;
     }
     ```
 
-2. 使用 `query-status <task-name>` 查看任务状态
+2. Use `query-status <task-name>` to view the task status:
 
     {{< copyable "" >}}
 
@@ -487,7 +487,7 @@ ALTER TABLE `db1`.`tbl1` ADD COLUMN new_col INT UNIQUE;
     » query-status test
     ```
 
-    <details><summary> 执行结果 </summary>
+    <details><summary> See the execution result.</summary>
 
     ```
     {
@@ -534,16 +534,16 @@ ALTER TABLE `db1`.`tbl1` ADD COLUMN new_col INT UNIQUE;
 
     </details>
 
-    可以看到任务运行正常，错误的 DDL 已被替换且执行成功。
+    You can see that the task runs normally and the wrong DDL statement is replaced by new DDL statements that execute successfully.
 
-#### 合库合表场景
+#### Shard merge scenario
 
-假设现在存在如下四个上游表需要合并迁移到下游的同一个表 ``` `shard_db`.`shard_table` ```，任务模式为悲观协调模式：
+Assume that you need to merge and migrate the following four tables in the upstream to one same table ``` `shard_db`.`shard_table` ``` in the downstream. The task mode is "pessimistic".
 
-- MySQL 实例 1 内有 `shard_db_1` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
-- MySQL 实例 2 内有 `shard_db_2` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
+- In the MySQL instance 1, there is a schema `shard_db_1`, which has two tables `shard_table_1` and `shard_table_2`.
+- In the MySQL instance 2, there is a schema `shard_db_2`, which has two tables `shard_table_1` and `shard_table_2`.
 
-初始时表结构为：
+The initial table schema is:
 
 {{< copyable "sql" >}}
 
@@ -551,7 +551,7 @@ ALTER TABLE `db1`.`tbl1` ADD COLUMN new_col INT UNIQUE;
 SHOW CREATE TABLE shard_db.shard_table;
 ```
 
-```
+```sql
 +-------+-----------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                              |
 +-------+-----------------------------------------------------------------------------------------------------------+
@@ -562,7 +562,7 @@ SHOW CREATE TABLE shard_db.shard_table;
 +-------+-----------------------------------------------------------------------------------------------------------+
 ```
 
-此时，在上游所有分表上都执行以下 DDL 操作增加新列，并添加 UNIQUE 约束：
+Now, perform the following DDL operation to all upstream sharded tables to add a new column with the UNIQUE constraint:
 
 {{< copyable "sql" >}}
 
@@ -570,7 +570,7 @@ SHOW CREATE TABLE shard_db.shard_table;
 ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
 ```
 
-则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status` 命令可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_1` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_1` 表报错：
+Because this DDL statement is not supported by TiDB, the migration task gets interrupted. Execute the `query-status` command, and you can see the following errors reported by the `shard_db_1`.`shard_table_1` table in MySQL instance 1 and the `shard_db_2`.`shard_table_1` table in MySQL instance 2:
 
 ```
 {
@@ -586,9 +586,9 @@ ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
 }
 ```
 
-我们将该 DDL 替换成两条等价的 DDL。操作步骤如下：
+You can replace this DDL statement with two equivalent DDL statements. The steps are as follows:
 
-1. 使用如下命令分别替换 MySQL 实例 1 和实例 2 中错误的 DDL 语句
+1. Replace the wrong DDL statements respectively in MySQL instance 1 and MySQL instance 2 by the following commands:
 
     {{< copyable "" >}}
 
@@ -632,7 +632,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
     }
     ```
 
-2. 使用 `query-status <task-name>` 查看任务状态，可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_2` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_2` 表报错：
+2. Use `query-status <task-name>` to view the task status, and you can see the following errors reported by the `shard_db_1`.`shard_table_2` table in MySQL instance 1 and the `shard_db_2`.`shard_table_2` table in MySQL instance 2:
 
     ```
     {
@@ -646,7 +646,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
     }
     ```
 
-3. 使用如下命令继续分别替换 MySQL 实例 1 和实例 2 中错误的 DDL 语句
+3. Execute `handle-error <task-name> replace` again to replace the wrong DDL statements in MySQL instance 1 and 2:
 
     {{< copyable "" >}}
 
@@ -690,7 +690,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
     }
     ```
 
-4. 使用 `query-status <task-name>` 查看任务状态
+4. Use `query-status <task-name>` to view the task status:
 
     {{< copyable "" >}}
 
@@ -698,7 +698,7 @@ ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
     » query-status test
     ```
 
-    <details><summary> 执行结果 </summary>
+    <details><summary> See the execution result.</summary>
 
     ```
     {
@@ -783,4 +783,4 @@ ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
 
     </details>
 
-    可以看到任务运行正常，无错误信息。四条 DDL 全部被替换。
+    You can see that the task runs normally with no error and all four wrong DDL statements are replaced.

--- a/en/overview.md
+++ b/en/overview.md
@@ -14,7 +14,7 @@ aliases: ['/docs/tidb-data-migration/dev/overview/']
 
 - [High availability of data migration task](#high-availability). The data migration task can run normally even when some DM-master or DM-worker nodes fail.
 - [Sharding DDL support in the optimistic mode](feature-shard-merge-optimistic.md). In this mode, migration latency can be reduced in some scenarios and you can make A/B changes in the upstream database.
-- Better usability, including the new [error handling mechanism](handle-failed-sql-statements.md) and the easier-to-read error messages and error handling suggestions.
+- Better usability, including the new [error handling mechanism](handle-failed-ddl-statements.md) and the easier-to-read error messages and error handling suggestions.
 - [TLS support](enable-tls.md) for connections between the upstream and the downstream, and for connections between DM components.
 - Support for migrating data from MySQL 8.0 (experimental).
 

--- a/zh/TOC.md
+++ b/zh/TOC.md
@@ -43,7 +43,7 @@
     - [暂停任务](pause-task.md)
     - [恢复任务](resume-task.md)
     - [停止任务](stop-task.md)
-    - [处理出错的 SQL 语句](handle-failed-sql-statements.md)
+    - [处理出错的 DDL 语句](handle-failed-ddl-statements.md)
   - [手动处理 Sharding DDL Lock](manually-handling-sharding-ddl-locks.md)
   - [管理迁移中表的表结构](manage-schema.md)
   - [告警处理](handle-alerts.md)

--- a/zh/_index.md
+++ b/zh/_index.md
@@ -12,7 +12,7 @@ DM 2.0 相比于 1.0，主要有以下改进：
 
 - [数据迁移任务的高可用](overview.md#高可用)，部分 DM-master、DM-worker 节点异常后仍能保证数据迁移任务的正常运行。
 - [乐观协调模式下的 sharding DDL](feature-shard-merge-optimistic.md) 可以在部分场景下减少 sharding DDL 同步过程中的延迟、支持上游数据库灰度变更等场景。
-- 更好的易用性，包括新的[错误处理机制](handle-failed-sql-statements.md)及更清晰易读的错误信息与错误处理建议。
+- 更好的易用性，包括新的[错误处理机制](handle-failed-ddl-statements.md)及更清晰易读的错误信息与错误处理建议。
 - 与上下游数据库及 DM 各组件间连接的 [TLS 支持](enable-tls.md)。
 - 实验性地支持从 MySQL 8.0 迁移数据。
 

--- a/zh/faq.md
+++ b/zh/faq.md
@@ -21,7 +21,7 @@ DM 会尝试将包含多个 DDL 变更操作的单条语句拆分成只包含一
 
 ## 如何处理不兼容的 DDL 语句？
 
-你需要使用 dmctl 手动处理 TiDB 不兼容的 DDL 语句（包括手动跳过该 DDL 语句或使用用户指定的 DDL 语句替换原 DDL 语句，详见[处理出错的 SQL 语句](handle-failed-sql-statements.md)）。
+你需要使用 dmctl 手动处理 TiDB 不兼容的 DDL 语句（包括手动跳过该 DDL 语句或使用用户指定的 DDL 语句替换原 DDL 语句，详见[处理出错的 DDL 语句](handle-failed-ddl-statements.md)）。
 
 > **注意：**
 >

--- a/zh/handle-failed-ddl-statements.md
+++ b/zh/handle-failed-ddl-statements.md
@@ -1,41 +1,41 @@
 ---
-title: Handle Failed SQL Statements
-summary: Learn how to handle failed SQL statements when you're using the TiDB Data Migration tool to migrate data.
-aliases: ['/docs/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/','/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements']
+title: 处理出错的 DDL 语句
+summary: 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 DDL 语句。
+aliases: ['/docs-cn/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/','/zh/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements','/zh/tidb-data-migration/dev/handle-failed-sql-statements']
 ---
 
-# Handle Failed SQL Statements
+# 处理出错的 DDL 语句
 
-This document introduces how to handle failed SQL statements when you're using the TiDB Data Migration (DM) tool to migrate data.
+本文介绍了如何使用 DM 来处理出错的 DDL 语句。
 
-Currently, TiDB is not completely compatible with all MySQL syntax (see [the DDL statements supported by TiDB](https://pingcap.com/docs/dev/reference/mysql-compatibility/#ddl)). Therefore, when DM is migrating data from MySQL to TiDB and TiDB does not support the corresponding SQL statement, an error might occur and break the migration process. In this case, you can use the `handle-error` command of DM to resume the migration.
+目前，TiDB 并不完全兼容所有的 MySQL 语法（详见 [TiDB 已支持的 DDL 语句](https://pingcap.com/docs-cn/dev/reference/mysql-compatibility/#ddl)）。当使用 DM 从 MySQL 迁移数据到 TiDB 时，如果 TiDB 不支持对应的 DDL 语句，可能会造成错误并中断迁移任务。在这种情况下，DM 提供 `handle-error` 命令来恢复迁移。
 
-## Restrictions
+## 使用限制
 
-If it is unacceptable in the actual production environment that the failed DDL statement is skipped in the downstream TiDB and it cannot be replaced with other DDL statements, then do not use this command.
+如果业务不能接受下游 TiDB 跳过异常的 DDL 语句，也不接受使用其他 DDL 语句作为替代，则不适合使用此方式进行处理。
 
-For example, `DROP PRIMARY KEY`. In this scenario, you can only create a new table in the downstream with the new table schema (after executing the DDL statement), and re-import all the data into this new table.
+比如：`DROP PRIMARY KEY`，这种情况下，只能在下游重建一个（DDL 执行完后的）新表结构对应的表，并将原表的全部数据重新导入该新表。
 
-## Supported scenarios
+## 支持场景
 
-During the migration, the DDL statement unsupported by TiDB is executed in the upstream and migrated to the downstream, and as a result, the migration task gets interrupted.
+迁移过程中，上游执行了 TiDB 不支持的 DDL 语句并迁移到了 DM，造成迁移任务中断。
 
-- If it is acceptable that this DDL statement is skipped in the downstream TiDB, then you can use `handle-error <task-name> skip` to skip migrating this DDL statement and resume the migration.
-- If it is acceptable that this DDL statement is replaced with other DDL statements, then you can use `handle-error <task-name> replace` to replace this DDL statement and resume the migration.
+- 如果业务能接受下游 TiDB 不执行该 DDL 语句，则使用 `handle-error <task-name> skip` 跳过对该 DDL 语句的迁移以恢复迁移任务。
+- 如果业务能接受下游 TiDB 执行其他 DDL 语句来作为替代，则使用 `handle-error <task-name> replace` 替代该 DDL 的迁移以恢复迁移任务。
 
-## Command
+## 命令介绍
 
-When you use dmctl to manually handle the failed SQL statements, the commonly used commands include `query-status` and `handle-error`.
+使用 dmctl 手动处理出错的 DDL 语句时，主要使用的命令包括 `query-status`、`handle-error`。
 
 ### query-status
 
-The `query-status` command is used to query the current status of items such as the subtask and the relay unit in each MySQL instance. For details, see [query status](query-status.md).
+`query-status` 命令用于查询当前 MySQL 实例内子任务及 relay 单元等的状态和错误信息，详见[查询状态](query-status.md)。
 
 ### handle-error
 
-The `handle-error` command is used to handle the failed SQL statements.
+`handle-error` 命令用于处理错误的 DDL 语句。
 
-### Command usage
+### 命令用法
 
 ```bash
 » handle-error -h
@@ -53,35 +53,35 @@ Global Flags:
   -s, --source strings   MySQL Source ID
 ```
 
-### Flags descriptions
+### 参数解释
 
-+ `task-name`:
-    - Non-flag parameter, string, required
-    - `task-name` specifies the name of the task in which the presetted operation is going to be executed.
++ `task-name`：
+    - 非 flag 参数，string，必选；
+    - 指定预设的操作将生效的任务。
 
-+ `source`:
-    - Flag parameter, string, `--source`
-    - `source` specifies the MySQL instance in which the preset operation is to be executed.
++ `source`：
+    - flag 参数，string，`--source`；
+    - `source` 指定预设操作将生效的 MySQL 实例。
 
-+ `skip`: Skip the error
++ `skip`：跳过该错误
 
-+ `replace`: Replace the failed SQL statement
++ `replace`：替代错误的 DDL 语句
 
-+ `revert`: Reset the previous skip/replace operation before the error occurs (only reset it when the previous skip/replace operation has not finally taken effect)
++ `revert`：重置该错误先前的 skip/replace 操作, 仅在先前的操作没有最终生效前执行
 
-+ `binlog-pos`:
-    - Flag parameter, string, `--binlog-pos`
-    - If it is not specified, DM automatically handles the currently failed SQL statement.
-    - If it is specified, the skip operation is executed when `binlog-pos` matches with the position of the binlog event. The format is `binlog-filename:binlog-pos`, for example, `mysql-bin|000001.000003:3270`.
-    - After the migration returns an error, the binlog position can be obtained from `position` in `startLocation` returned by `query-status`. Before the migration returns an error, the binlog position can be obtained by using [`SHOW BINLOG EVENTS`](https://dev.mysql.com/doc/refman/5.7/en/show-binlog-events.html) in the upstream MySQL instance.
++ `binlog-pos`：
+    - flag 参数，string，`--binlog-pos`；
+    - 若不指定，DM 会自动处理当前出错的 DDL 语句
+    - 在指定时表示操作将在 `binlog-pos` 与 binlog event 的 position 匹配时生效，格式为 `binlog-filename:binlog-pos`，如 `mysql-bin|000001.000003:3270`。
+    - 在迁移执行出错后，binlog position 可直接从 `query-status` 返回的 `startLocation` 中的 `position` 获得；在迁移执行出错前，binlog position 可在上游 MySQL 中使用 [`SHOW BINLOG EVENTS`](https://dev.mysql.com/doc/refman/5.7/en/show-binlog-events.html) 获得。
 
-## Usage examples
+## 使用示例
 
-### Skip SQL if the migration gets interrupted
+### 迁移中断执行跳过操作
 
-#### Non-shard-merge scenario
+#### 非合库合表场景
 
-Assume that you need to migrate the upstream table `db1.tbl1` to the downstream TiDB. The initial table schema is:
+假设现在需要将上游的 `db1.tbl1` 表迁移到下游 TiDB，初始时表结构为：
 
 {{< copyable "sql" >}}
 
@@ -89,7 +89,7 @@ Assume that you need to migrate the upstream table `db1.tbl1` to the downstream 
 SHOW CREATE TABLE db1.tbl1;
 ```
 
-```sql
+```
 +-------+--------------------------------------------------+
 | Table | Create Table                                     |
 +-------+--------------------------------------------------+
@@ -101,7 +101,7 @@ SHOW CREATE TABLE db1.tbl1;
 +-------+--------------------------------------------------+
 ```
 
-Now, the following DDL statement is executed in the upstream to alter the table schema (namely, alter DECIMAL(11, 3) of c2 into DECIMAL(10, 3)):
+此时，上游执行以下 DDL 操作修改表结构（将列的 DECIMAL(11, 3) 修改为 DECIMAL(10, 3)）：
 
 {{< copyable "sql" >}}
 
@@ -109,15 +109,15 @@ Now, the following DDL statement is executed in the upstream to alter the table 
 ALTER TABLE db1.tbl1 CHANGE c2 c2 DECIMAL (10, 3);
 ```
 
-Because this DDL statement is not supported by TiDB, the migration task of DM gets interrupted. Execute the `query-status <task-name>` command, and you can see the following error:
+则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status <task-name>` 命令可看到如下错误：
 
 ```
 ERROR 8200 (HY000): Unsupported modify column: can't change decimal column precision
 ```
 
-Assume that it is acceptable in the actual production environment that this DDL statement is not executed in the downstream TiDB (namely, the original table schema is retained). Then you can use `handle-error <task-name> skip` to skip this DDL statement to resume the migration. The procedures are as follows:
+假设业务上可以接受下游 TiDB 不执行此 DDL 语句（即继续保持原有的表结构），则可以通过使用 `handle-error <task-name> skip` 命令跳过该 DDL 语句以恢复迁移任务。操作步骤如下：
 
-1. Execute `handle-error <task-name> skip` to skip the currently failed DDL statement:
+1. 使用 `handle-error <task-name> skip` 跳过当前错误的 DDL 语句
 
     {{< copyable "" >}}
 
@@ -140,7 +140,7 @@ Assume that it is acceptable in the actual production environment that this DDL 
     }
     ```
 
-2. Execute `query-status <task-name>` to view the task status:
+2. 使用 `query-status <task-name>` 查看任务状态
 
     {{< copyable "" >}}
 
@@ -148,7 +148,7 @@ Assume that it is acceptable in the actual production environment that this DDL 
     » query-status test
     ```
 
-    <details><summary> See the execution result.</summary>
+    <details><summary> 执行结果 </summary>
 
     ```
     {
@@ -195,16 +195,16 @@ Assume that it is acceptable in the actual production environment that this DDL 
 
     </details>
 
-    You can see that the task runs normally and the wrong DDL is skipped.
+    可以看到任务运行正常，错误的 DDL 被跳过。
 
-#### Shard merge scenario
+#### 合库合表场景
 
-Assume that you need to merge and migrate the following four tables in the upstream to one same table ``` `shard_db`.`shard_table` ``` in the downstream. The task mode is "pessimistic".
+假设现在存在如下四个上游表需要合并迁移到下游的同一个表 ``` `shard_db`.`shard_table` ```，任务模式为悲观协调模式：
 
-- MySQL instance 1 contains the `shard_db_1` schema, which includes the `shard_table_1` and `shard_table_2` tables.
-- MySQL instance 2 contains the `shard_db_2` schema, which includes the `shard_table_1` and `shard_table_2` tables.
+- MySQL 实例 1 内有 `shard_db_1` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
+- MySQL 实例 2 内有 `shard_db_2` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
 
-The initial table schema is:
+初始时表结构为：
 
 {{< copyable "sql" >}}
 
@@ -212,7 +212,7 @@ The initial table schema is:
 SHOW CREATE TABLE shard_db.shard_table;
 ```
 
-```sql
+```
 +-------+-----------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                              |
 +-------+-----------------------------------------------------------------------------------------------------------+
@@ -223,7 +223,7 @@ SHOW CREATE TABLE shard_db.shard_table;
 +-------+-----------------------------------------------------------------------------------------------------------+
 ```
 
-Now, execute the following DDL statement to all upstream sharded tables to alter their character set:
+此时，在上游所有分表上都执行以下 DDL 操作修改表字符集
 
 {{< copyable "sql" >}}
 
@@ -231,7 +231,7 @@ Now, execute the following DDL statement to all upstream sharded tables to alter
 ALTER TABLE `shard_db_*`.`shard_table_*` CHARACTER SET LATIN1 COLLATE LATIN1_DANISH_CI;
 ```
 
-Because this DDL statement is not supported by TiDB, the migration task of DM gets interrupted. Execute the `query-status` command, and you can see the following errors reported by the `shard_db_1`.`shard_table_1` table in MySQL instance 1 and the `shard_db_2`.`shard_table_1` table in MySQL instance 2:
+则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status` 命令可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_1` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_1` 表报错：
 
 ```
 {
@@ -247,9 +247,9 @@ Because this DDL statement is not supported by TiDB, the migration task of DM ge
 }
 ```
 
-Assume that it is acceptable in the actual production environment that this DDL statement is not executed in the downstream TiDB (namely, the original table schema is retained). Then you can use `handle-error <task-name> skip` to skip this DDL statement to resume the migration. The procedures are as follows:
+假设业务上可以接受下游 TiDB 不执行此 DDL 语句（即继续保持原有的表结构），则可以通过使用 `handle-error <task-name> skip` 命令跳过该 DDL 语句以恢复迁移任务。操作步骤如下：
 
-1. Execute `handle-error <task-name> skip` to skip the currently failed DDL statements in MySQL instance 1 and 2:
+1. 使用 `handle-error <task-name> skip` 跳过 MySQL 实例 1 和实例 2 当前错误的 DDL 语句
 
     {{< copyable "" >}}
 
@@ -278,7 +278,7 @@ Assume that it is acceptable in the actual production environment that this DDL 
     }
     ```
 
-2. Execute the `query-status` command, and you can see the errors reported by the `shard_db_1`.`shard_table_2` table in MySQL instance 1 and the `shard_db_2`.`shard_table_2` table in MySQL instance 2:
+2. 使用 `query-status <task-name>` 查看任务状态，可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_2` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_2` 表报错：
 
     ```
     {
@@ -294,7 +294,7 @@ Assume that it is acceptable in the actual production environment that this DDL 
     }
     ```
 
-3. Execute `handle-error <task-name> skip` again to skip the currently failed DDL statements in MySQL instance 1 and 2:
+3. 继续使用 `handle-error <task-name> skip` 跳过 MySQL 实例 1 和实例 2 当前错误的 DDL 语句
 
     {{< copyable "" >}}
 
@@ -323,7 +323,7 @@ Assume that it is acceptable in the actual production environment that this DDL 
     }
     ```
 
-4. Use `query-status <task-name>` to view the task status:
+4. 使用 `query-status <task-name>` 查看任务状态
 
     {{< copyable "" >}}
 
@@ -331,7 +331,7 @@ Assume that it is acceptable in the actual production environment that this DDL 
     » query-status test
     ```
 
-    <details><summary> See the execution result.</summary>
+    <details><summary> 执行结果 </summary>
 
     ```
     {
@@ -412,13 +412,13 @@ Assume that it is acceptable in the actual production environment that this DDL 
 
     </details>
 
-    You can see that the task runs normally with no error and all four wrong DDL statements are skipped.
+    可以看到任务运行正常，无错误信息。四条 DDL 全部被跳过。
 
-### Replace SQL if the migration gets interrupted
+### 迁移中断执行替代操作
 
-#### Non-shard-merge scenario
+#### 非合库合表场景
 
-Assume that you need to migrate the upstream table `db1.tbl1` to the downstream TiDB. The initial table schema is:
+假设现在需要将上游的 `db1.tbl1` 表迁移到下游 TiDB，初始时表结构为：
 
 {{< copyable "sql" >}}
 
@@ -426,7 +426,7 @@ Assume that you need to migrate the upstream table `db1.tbl1` to the downstream 
 SHOW CREATE TABLE db1.tbl1;
 ```
 
-```SQL
+```
 +-------+-----------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                              |
 +-------+-----------------------------------------------------------------------------------------------------------+
@@ -437,7 +437,7 @@ SHOW CREATE TABLE db1.tbl1;
 +-------+-----------------------------------------------------------------------------------------------------------+
 ```
 
-Now, perform the following DDL operation in the upstream to add a new column with the UNIQUE constraint:
+此时，上游执行以下 DDL 操作增加新列，并添加 UNIQUE 约束
 
 {{< copyable "sql" >}}
 
@@ -445,7 +445,7 @@ Now, perform the following DDL operation in the upstream to add a new column wit
 ALTER TABLE `db1`.`tbl1` ADD COLUMN new_col INT UNIQUE;
 ```
 
-Because this DDL statement is not supported by TiDB, the migration task gets interrupted. Execute the `query-status` command, and you can see the following error:
+则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status` 命令可看到如下错误：
 
 ```
 {
@@ -454,9 +454,9 @@ Because this DDL statement is not supported by TiDB, the migration task gets int
 }
 ```
 
-You can replace this DDL statement with two equivalent DDL statements. The steps are as follows:
+我们将该 DDL 替换成两条等价的 DDL。操作步骤如下：
 
-1. Replace the wrong DDL statement by the following command:
+1. 使用如下命令替换错误的 DDL 语句
 
     {{< copyable "" >}}
 
@@ -479,7 +479,7 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
     }
     ```
 
-2. Use `query-status <task-name>` to view the task status:
+2. 使用 `query-status <task-name>` 查看任务状态
 
     {{< copyable "" >}}
 
@@ -487,7 +487,7 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
     » query-status test
     ```
 
-    <details><summary> See the execution result.</summary>
+    <details><summary> 执行结果 </summary>
 
     ```
     {
@@ -534,16 +534,16 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
 
     </details>
 
-    You can see that the task runs normally and the wrong DDL statement is replaced by new DDL statements that execute successfully.
+    可以看到任务运行正常，错误的 DDL 已被替换且执行成功。
 
-#### Shard merge scenario
+#### 合库合表场景
 
-Assume that you need to merge and migrate the following four tables in the upstream to one same table ``` `shard_db`.`shard_table` ``` in the downstream. The task mode is "pessimistic".
+假设现在存在如下四个上游表需要合并迁移到下游的同一个表 ``` `shard_db`.`shard_table` ```，任务模式为悲观协调模式：
 
-- In the MySQL instance 1, there is a schema `shard_db_1`, which has two tables `shard_table_1` and `shard_table_2`.
-- In the MySQL instance 2, there is a schema `shard_db_2`, which has two tables `shard_table_1` and `shard_table_2`.
+- MySQL 实例 1 内有 `shard_db_1` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
+- MySQL 实例 2 内有 `shard_db_2` 库，包括 `shard_table_1` 和 `shard_table_2` 两个表。
 
-The initial table schema is:
+初始时表结构为：
 
 {{< copyable "sql" >}}
 
@@ -551,7 +551,7 @@ The initial table schema is:
 SHOW CREATE TABLE shard_db.shard_table;
 ```
 
-```sql
+```
 +-------+-----------------------------------------------------------------------------------------------------------+
 | Table | Create Table                                                                                              |
 +-------+-----------------------------------------------------------------------------------------------------------+
@@ -562,7 +562,7 @@ SHOW CREATE TABLE shard_db.shard_table;
 +-------+-----------------------------------------------------------------------------------------------------------+
 ```
 
-Now, perform the following DDL operation to all upstream sharded tables to add a new column with the UNIQUE constraint:
+此时，在上游所有分表上都执行以下 DDL 操作增加新列，并添加 UNIQUE 约束：
 
 {{< copyable "sql" >}}
 
@@ -570,7 +570,7 @@ Now, perform the following DDL operation to all upstream sharded tables to add a
 ALTER TABLE `shard_db_*`.`shard_table_*` ADD COLUMN new_col INT UNIQUE;
 ```
 
-Because this DDL statement is not supported by TiDB, the migration task gets interrupted. Execute the `query-status` command, and you can see the following errors reported by the `shard_db_1`.`shard_table_1` table in MySQL instance 1 and the `shard_db_2`.`shard_table_1` table in MySQL instance 2:
+则会由于 TiDB 不支持该 DDL 语句而导致 DM 迁移任务中断，使用 `query-status` 命令可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_1` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_1` 表报错：
 
 ```
 {
@@ -586,9 +586,9 @@ Because this DDL statement is not supported by TiDB, the migration task gets int
 }
 ```
 
-You can replace this DDL statement with two equivalent DDL statements. The steps are as follows:
+我们将该 DDL 替换成两条等价的 DDL。操作步骤如下：
 
-1. Replace the wrong DDL statements respectively in MySQL instance 1 and MySQL instance 2 by the following commands:
+1. 使用如下命令分别替换 MySQL 实例 1 和实例 2 中错误的 DDL 语句
 
     {{< copyable "" >}}
 
@@ -632,7 +632,7 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
     }
     ```
 
-2. Use `query-status <task-name>` to view the task status, and you can see the following errors reported by the `shard_db_1`.`shard_table_2` table in MySQL instance 1 and the `shard_db_2`.`shard_table_2` table in MySQL instance 2:
+2. 使用 `query-status <task-name>` 查看任务状态，可以看到 MySQL 实例 1 的 `shard_db_1`.`shard_table_2` 表和 MySQL 实例 2 的 `shard_db_2`.`shard_table_2` 表报错：
 
     ```
     {
@@ -646,7 +646,7 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
     }
     ```
 
-3. Execute `handle-error <task-name> replace` again to replace the wrong DDL statements in MySQL instance 1 and 2:
+3. 使用如下命令继续分别替换 MySQL 实例 1 和实例 2 中错误的 DDL 语句
 
     {{< copyable "" >}}
 
@@ -690,7 +690,7 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
     }
     ```
 
-4. Use `query-status <task-name>` to view the task status:
+4. 使用 `query-status <task-name>` 查看任务状态
 
     {{< copyable "" >}}
 
@@ -698,7 +698,7 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
     » query-status test
     ```
 
-    <details><summary> See the execution result.</summary>
+    <details><summary> 执行结果 </summary>
 
     ```
     {
@@ -783,4 +783,4 @@ You can replace this DDL statement with two equivalent DDL statements. The steps
 
     </details>
 
-    You can see that the task runs normally with no error and all four wrong DDL statements are replaced.
+    可以看到任务运行正常，无错误信息。四条 DDL 全部被替换。

--- a/zh/overview.md
+++ b/zh/overview.md
@@ -11,7 +11,7 @@ DM 2.0 相比于 1.0，主要有以下改进：
 
 - [数据迁移任务的高可用](#高可用)，部分 DM-master、DM-worker 节点异常后仍能保证数据迁移任务的正常运行。
 - [乐观协调模式下的 sharding DDL](feature-shard-merge-optimistic.md) 可以在部分场景下减少 sharding DDL 同步过程中的延迟、支持上游数据库灰度变更等场景。
-- 更好的易用性，包括新的[错误处理机制](handle-failed-sql-statements.md)及更清晰易读的错误信息与错误处理建议。
+- 更好的易用性，包括新的[错误处理机制](handle-failed-ddl-statements.md)及更清晰易读的错误信息与错误处理建议。
 - 与上下游数据库及 DM 各组件间连接的 [TLS 支持](enable-tls.md)。
 - 实验性地支持从 MySQL 8.0 迁移数据。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. Please answer the following questions.-->

### What is changed, added, or deleted? (Required)
Update handle-error command description for v2.0.1
Now handle-error only support ddl statement.
<!--Tell us what you did and why.-->

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version, including v3.0 changes)
- [x] v2.0 (TiDB DM 2.0 versions)
- [ ] v1.0 (TiDB DM 1.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->
https://github.com/pingcap/dm/pull/1303
- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [x] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
