### PR TITLE
Update quick-start-create-task.md

### DIFF
--- a/zh/quick-start-create-task.md
+++ b/zh/quick-start-create-task.md
@@ -151,7 +151,7 @@ from:
 name: test
 task-mode: all
 shard-mode: "pessimistic"
-ignore-checking-items: ["auto_increment_ID"] #添加忽视 主键检查 选项
+ignore-checking-items: ["auto_increment_ID"] ＃添加忽略“主键检查”选项
 
 target-database:
   host: "127.0.0.1"

--- a/zh/quick-start-create-task.md
+++ b/zh/quick-start-create-task.md
@@ -43,8 +43,8 @@ docker run --rm --name mysql-3307 -p 3307:3307 -e MYSQL_ALLOW_EMPTY_PASSWORD=tru
     use `sharding1`;
     create table t1 (id bigint, uid int, name varchar(80), info varchar(100), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
     create table t2 (id bigint, uid int, name varchar(80), info varchar(100), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
-    insert into t1 (uid, name) values (10001, 'Gabriel García Márquez'), (10002, 'Cien años de soledad');
-    insert into t2 (uid, name) values (20001, 'José Arcadio Buendía'), (20002, 'Úrsula Iguarán'), (20003, 'José Arcadio');
+    insert into t1 (id, uid, name) values (1, 10001, 'Gabriel García Márquez'), (2 ,10002, 'Cien años de soledad');
+    insert into t2 (id, uid, name) values (3,20001, 'José Arcadio Buendía'), (4,20002, 'Úrsula Iguarán'), (5,20003, 'José Arcadio');
     ```
 
 - 向 mysql-3307 写入示例数据。
@@ -57,8 +57,8 @@ docker run --rm --name mysql-3307 -p 3307:3307 -e MYSQL_ALLOW_EMPTY_PASSWORD=tru
     use `sharding2`;
     create table t2 (id bigint, uid int, name varchar(80), info varchar(100), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
     create table t3 (id bigint, uid int, name varchar(80), info varchar(100), primary key (`id`), unique key(`uid`)) DEFAULT CHARSET=utf8mb4;
-    insert into t2 (uid, name, info) values (40000, 'Remedios Moscote', '{}');
-    insert into t3 (uid, name, info) values (30001, 'Aureliano José', '{}'), (30002, 'Santa Sofía de la Piedad', '{}'), (30003, '17 Aurelianos', NULL);
+    insert into t2 (id, uid, name, info) values (6, 40000, 'Remedios Moscote', '{}');
+    insert into t3 (id, uid, name, info) values 7, 30001, 'Aureliano José', '{}'), (8, 30002, 'Santa Sofía de la Piedad', '{}'), (9, 30003, '17 Aurelianos', NULL);
     ```
 
 ### 运行下游 TiDB
@@ -151,6 +151,7 @@ from:
 name: test
 task-mode: all
 shard-mode: "pessimistic"
+ignore-checking-items: ["auto_increment_ID"] #添加忽视 主键检查 选项
 
 target-database:
   host: "127.0.0.1"

--- a/zh/quick-start-create-task.md
+++ b/zh/quick-start-create-task.md
@@ -151,7 +151,6 @@ from:
 name: test
 task-mode: all
 shard-mode: "pessimistic"
-ignore-checking-items: ["auto_increment_ID"] ＃添加忽略“主键检查”选项
 
 target-database:
   host: "127.0.0.1"


### PR DESCRIPTION
The created table contains a primary key, but it‘s not an auto-increment primary key. So when inserting data, you need to actively add the value of the id column.
And we need to add the option to ignore the primary key check

<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-dm) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version, including v3.0 changes)
- [x] v2.0 (TiDB DM 2.0 versions)
- [ ] v1.0 (TiDB DM 1.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
