### PR TITLE
Remove the `skip-tz-utc` configuration item

### DIFF
--- a/zh/usage-scenario-simple-migration.md
+++ b/zh/usage-scenario-simple-migration.md
@@ -239,7 +239,6 @@ mydumpers:
   global:
     threads: 4
     chunk-filesize: 64
-    skip-tz-utc: true
 
 loaders:
   global:


### PR DESCRIPTION
dumpling does not have this parameter, the current behavior is skip-tz-utc: true

This variable exists in other places in the V2 document, please remove, more quantity
Please conduct technical review
@lance6716 

<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-dm) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version, including v3.0 changes)
- [x] v2.0 (TiDB DM 2.0 versions)
- [ ] v1.0 (TiDB DM 1.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
