### PR TITLE
feat: add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can use Google Translate to view the documentation in different languages. F
 - `ko`: [documentation in Korean](http://translate.google.com/translate?hl=en&sl=en&tl=ko&u=https%3A%2F%2Fgithub.com%2Fpingcap%2Fdocs-dm%2Fblob%2Fmaster%2Fen%2FTOC.md)
 - `id`: [documentation in Indonesian](http://translate.google.com/translate?hl=en&sl=en&tl=id&u=https%3A%2F%2Fgithub.com%2Fpingcap%2Fdocs-dm%2Fblob%2Fmaster%2Fen%2FTOC.md)
 
-## Contributor over time
+## Contributors over time
 
 [![Contributors over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=pingcap/docs-dm)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=pingcap/docs-dm)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ You can use Google Translate to view the documentation in different languages. F
 - `ko`: [documentation in Korean](http://translate.google.com/translate?hl=en&sl=en&tl=ko&u=https%3A%2F%2Fgithub.com%2Fpingcap%2Fdocs-dm%2Fblob%2Fmaster%2Fen%2FTOC.md)
 - `id`: [documentation in Indonesian](http://translate.google.com/translate?hl=en&sl=en&tl=id&u=https%3A%2F%2Fgithub.com%2Fpingcap%2Fdocs-dm%2Fblob%2Fmaster%2Fen%2FTOC.md)
 
+## Contributor over time
+
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=pingcap/docs-dm)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=pingcap/docs-dm)
+
 ## Documentation versions
 
 Currently, we maintain the following versions for TiDB DM documentation, each with a separate branch:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can use Google Translate to view the documentation in different languages. F
 
 ## Contributor over time
 
-[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=pingcap/docs-dm)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=pingcap/docs-dm)
+[![Contributors over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=pingcap/docs-dm)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=pingcap/docs-dm)
 
 ## Documentation versions
 


### PR DESCRIPTION
Hi, community!

To better present how our community grows, we develop a tool to show contributors growing history on [https://github.com/api7/contributor-graph](https://github.com/api7/contributor-graph). Since we found it helpful, we think maybe if it could help some other community.

## WHAT IT IS

Basically, it just shows the contributors growth over time, just like the stargazers over time on the README. It would be the same with stars that we would update the graph each day, so the link would always present the real-time data. There is some other stuff to play around with if you would like to give it a try~

![image](https://user-images.githubusercontent.com/72343596/119221283-2db3b900-bb21-11eb-9a8e-453e9bb426fd.png)

## HOW IT WORKS 

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each user.

Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻
