### PR TITLE
[2.0.4] dmctl: support read master addr from env

### DIFF
--- a/en/dmctl-introduction.md
+++ b/en/dmctl-introduction.md
@@ -83,6 +83,9 @@ The command mode differs from the interactive mode in that you need to append th
 ./dmctl --master-addr 172.16.30.14:8261 start-task task.yaml
 ./dmctl --master-addr 172.16.30.14:8261 stop-task task
 ./dmctl --master-addr 172.16.30.14:8261 query-status
+
+export DM_MASTER_ADD="172.16.30.14:8261"
+./dmctl query-status
 ```
 
 ```

--- a/en/dmctl-introduction.md
+++ b/en/dmctl-introduction.md
@@ -76,6 +76,8 @@ The command mode differs from the interactive mode in that you need to append th
 >
 > + A dmctl command must be followed by only one task operation.
 > + The task operation can be placed only at the end of the dmctl command.
+> + Starting from v2.0.4, the `-master-addr` parameter supports reading from environment variables (DM_MASTER_ADDR).
+
 
 {{< copyable "shell-regular" >}}
 

--- a/en/dmctl-introduction.md
+++ b/en/dmctl-introduction.md
@@ -85,6 +85,9 @@ The command mode differs from the interactive mode in that you need to append th
 ./dmctl -master-addr 172.16.30.14:8261 start-task task.yaml
 ./dmctl -master-addr 172.16.30.14:8261 stop-task task
 ./dmctl -master-addr 172.16.30.14:8261 query-status
+
+export DM_MASTER_ADD="172.16.30.14:8261"
+./dmctl query-status
 ```
 
 ```

--- a/en/dmctl-introduction.md
+++ b/en/dmctl-introduction.md
@@ -78,7 +78,6 @@ The command mode differs from the interactive mode in that you need to append th
 > + The task operation can be placed only at the end of the dmctl command.
 > + Starting from v2.0.4, the `-master-addr` parameter supports reading from environment variables (DM_MASTER_ADDR).
 
-
 {{< copyable "shell-regular" >}}
 
 ```bash

--- a/en/dmctl-introduction.md
+++ b/en/dmctl-introduction.md
@@ -75,7 +75,7 @@ The command mode differs from the interactive mode in that you need to append th
 > **Note:**
 >
 > + A dmctl command must be followed by only one task operation.
-> + Starting from v2.0.4, the `-master-addr` parameter supports reading from environment variables (DM_MASTER_ADDR).
+> + Starting from v2.0.4, DM supports reading the `-master-addr` parameter from the environment variable `DM_MASTER_ADDR`.
 
 {{< copyable "shell-regular" >}}
 

--- a/zh/dmctl-introduction.md
+++ b/zh/dmctl-introduction.md
@@ -83,6 +83,9 @@ Use "dmctl [command] --help" for more information about a command.
 ./dmctl --master-addr 172.16.30.14:8261 start-task task.yaml
 ./dmctl --master-addr 172.16.30.14:8261 stop-task task
 ./dmctl --master-addr 172.16.30.14:8261 query-status
+
+export DM_MASTER_ADD="172.16.30.14:8261"
+./dmctl query-status
 ```
 
 ```

--- a/zh/dmctl-introduction.md
+++ b/zh/dmctl-introduction.md
@@ -75,7 +75,7 @@ Use "dmctl [command] --help" for more information about a command.
 > **注意：**
 >
 > + 一条 dmctl 命令只能跟一个任务操作
-> + 从 v2.0.4 版本开始，支持从环境变量(DM_MASTER_ADDR)里读取 `-master-addr` 参数
+> + 从 v2.0.4 版本开始，支持从环境变量 (DM_MASTER_ADDR) 里读取 `-master-addr` 参数
 
 {{< copyable "shell-regular" >}}
 

--- a/zh/dmctl-introduction.md
+++ b/zh/dmctl-introduction.md
@@ -76,7 +76,7 @@ Use "dmctl [command] --help" for more information about a command.
 >
 > + 一条 dmctl 命令只能跟一个任务操作
 > + 任务操作只能放在 dmctl 命令的最后
-> + 从 v2.0.4 版本开始, `-master-addr`参数支持从环境变量(DM_MASTER_ADDR)里读取
+> + 从 v2.0.4 版本开始，支持从环境变量(DM_MASTER_ADDR)里读取 `-master-addr` 参数
 
 {{< copyable "shell-regular" >}}
 
@@ -84,6 +84,9 @@ Use "dmctl [command] --help" for more information about a command.
 ./dmctl -master-addr 172.16.30.14:8261 start-task task.yaml
 ./dmctl -master-addr 172.16.30.14:8261 stop-task task
 ./dmctl -master-addr 172.16.30.14:8261 query-status
+
+export DM_MASTER_ADD="172.16.30.14:8261"
+./dmctl query-status
 ```
 
 ```

--- a/zh/dmctl-introduction.md
+++ b/zh/dmctl-introduction.md
@@ -76,6 +76,7 @@ Use "dmctl [command] --help" for more information about a command.
 >
 > + 一条 dmctl 命令只能跟一个任务操作
 > + 任务操作只能放在 dmctl 命令的最后
+> + 从 v2.0.4 版本开始, `-master-addr`参数支持从环境变量(DM_MASTER_ADDR)里读取
 
 {{< copyable "shell-regular" >}}
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Data Migration (DM) documentation. Please answer the following questions.-->

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->
update dmctl doc to note that `master_addr` can be read from env var.

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version, including v3.0 changes)
- [x] v2.0 (TiDB DM 2.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/dm/pull/1726

### Do your changes match any of the following descriptions?

- [x] Change aliases
