### PR TITLE
add aliases for DM 2.0 benchmark reports

### DIFF
--- a/en/benchmark-v2.0-ga.md
+++ b/en/benchmark-v2.0-ga.md
@@ -1,6 +1,7 @@
 ---
 title: DM 2.0-GA Benchmark Report
 summary: Learn about the performance of DM 2.0-GA.
+aliases: ['/zh/tidb-data-migration/dev/benchmark-v2.0-ga/']
 ---
 
 # DM 2.0-GA Benchmark Report

--- a/en/benchmark-v2.0-ga.md
+++ b/en/benchmark-v2.0-ga.md
@@ -1,7 +1,7 @@
 ---
 title: DM 2.0-GA Benchmark Report
 summary: Learn about the performance of DM 2.0-GA.
-aliases: ['/zh/tidb-data-migration/dev/benchmark-v2.0-ga/']
+aliases: ['/tidb-data-migration/dev/benchmark-v2.0-ga/']
 ---
 
 # DM 2.0-GA Benchmark Report

--- a/zh/benchmark-v2.0-ga.md
+++ b/zh/benchmark-v2.0-ga.md
@@ -1,6 +1,7 @@
 ---
 title: DM 2.0-GA 性能测试报告
 summary: 了解 DM 2.0-GA 版本的性能。
+aliases: ['/tidb-data-migration/dev/benchmark-v2.0-ga/']
 ---
 
 # DM 2.0-GA 性能测试报告

--- a/zh/benchmark-v2.0-ga.md
+++ b/zh/benchmark-v2.0-ga.md
@@ -1,7 +1,7 @@
 ---
 title: DM 2.0-GA 性能测试报告
 summary: 了解 DM 2.0-GA 版本的性能。
-aliases: ['/tidb-data-migration/dev/benchmark-v2.0-ga/']
+aliases: ['/zh/tidb-data-migration/dev/benchmark-v2.0-ga/']
 ---
 
 # DM 2.0-GA 性能测试报告


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

The 2.0 benchmark reports will not be kept in the dev branch after the following PRs are merged. So this PR adds the corresponding aliases to avoid the 404 error when users open https://docs.pingcap.com/zh/tidb-data-migration/dev/benchmark-v2.0-ga/. 

https://github.com/pingcap/docs-cn/pull/8042
https://github.com/pingcap/docs/pull/7317

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v5.3 (TiDB DM 5.3 versions)
- [x] v2.0 (TiDB DM 2.0 versions)
- [ ] v1.0 (TiDB DM 1.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [x] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
