### PR TITLE
add aliases for DM 1.0 benchmark reports

### DIFF
--- a/en/benchmark-v1-alpha.md
+++ b/en/benchmark-v1-alpha.md
@@ -1,7 +1,7 @@
 ---
 title: DM 1.0-alpha Benchmark Report
 summary: Learn about the DM 1.0-alpha benchmark report.
-aliases: ['/docs/tidb-data-migration/stable/benchmark-v1-alpha/','/docs/tidb-data-migration/v1.0/benchmark-v1-alpha/','/docs/dev/benchmark/dm-v1-alpha/','/docs/v3.0/benchmark/dm-v1-alpha/','/docs/v3.1/benchmark/dm-v1-alpha/','/docs/v2.1/benchmark/dm-v1-alpha/']
+aliases: ['/docs/tidb-data-migration/stable/benchmark-v1-alpha/','/docs/tidb-data-migration/v1.0/benchmark-v1-alpha/','/docs/dev/benchmark/dm-v1-alpha/','/docs/v3.0/benchmark/dm-v1-alpha/','/docs/v3.1/benchmark/dm-v1-alpha/','/docs/v2.1/benchmark/dm-v1-alpha/','/tidb-data-migration/dev/benchmark-v1-alpha/']
 ---
 
 # DM 1.0-alpha Benchmark Report

--- a/en/benchmark-v1.0-ga.md
+++ b/en/benchmark-v1.0-ga.md
@@ -1,7 +1,7 @@
 ---
 title: DM 1.0-GA Benchmark Report
 summary: Learn about the DM 1.0-GA benchmark report.
-aliases: ['/docs/tidb-data-migration/stable/benchmark-v1.0-ga/','/docs/tidb-data-migration/v1.0/benchmark-v1.0-ga/','/docs/dev/benchmark/dm-v1.0-ga/','/docs/v3.0/benchmark/dm-v1.0-ga/','/docs/v3.1/benchmark/dm-v1.0-ga/','/docs/stable/benchmark/dm-v1.0-ga/']
+aliases: ['/docs/tidb-data-migration/stable/benchmark-v1.0-ga/','/docs/tidb-data-migration/v1.0/benchmark-v1.0-ga/','/docs/dev/benchmark/dm-v1.0-ga/','/docs/v3.0/benchmark/dm-v1.0-ga/','/docs/v3.1/benchmark/dm-v1.0-ga/','/docs/stable/benchmark/dm-v1.0-ga/','/tidb-data-migration/dev/benchmark-v1.0-ga/']
 ---
 
 # DM 1.0-GA Benchmark Report

--- a/zh/benchmark-v1.0-ga.md
+++ b/zh/benchmark-v1.0-ga.md
@@ -1,6 +1,6 @@
 ---
 title: DM 1.0-GA 性能测试报告
-aliases: ['/docs-cn/tidb-data-migration/stable/benchmark-v1.0-ga/','/docs-cn/tidb-data-migration/v1.0/benchmark-v1.0-ga/','/docs-cn/dev/benchmark/dm-v1.0-ga/','/docs-cn/v3.0/benchmark/dm-v1.0-ga/','/docs-cn/v3.1/benchmark/dm-v1.0-ga/','/docs-cn/stable/benchmark/dm-v1.0-ga/']
+aliases: ['/docs-cn/tidb-data-migration/stable/benchmark-v1.0-ga/','/docs-cn/tidb-data-migration/v1.0/benchmark-v1.0-ga/','/docs-cn/dev/benchmark/dm-v1.0-ga/','/docs-cn/v3.0/benchmark/dm-v1.0-ga/','/docs-cn/v3.1/benchmark/dm-v1.0-ga/','/docs-cn/stable/benchmark/dm-v1.0-ga/','/zh/tidb-data-migration/dev/benchmark-v1.0-ga/']
 ---
 
 # DM 1.0-GA 性能测试报告


### PR DESCRIPTION


### What is changed, added, or deleted? (Required)

The 1.0 benchmark reports will not be kept in the dev branch after the following PRs are merged. So this PR adds the corresponding aliases to avoid the 404 error when users open https://docs.pingcap.com/zh/tidb-data-migration/dev/benchmark-v1.0-ga/. 

https://github.com/pingcap/docs-cn/pull/8042
https://github.com/pingcap/docs/pull/7317

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v5.3 (TiDB DM 5.3 versions)
- [ ] v2.0 (TiDB DM 2.0 versions)
- [x] v1.0 (TiDB DM 1.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [x] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
