### PR TITLE
Add doc location change info of DM documentation

### DIFF
--- a/en/_index.md
+++ b/en/_index.md
@@ -9,6 +9,7 @@ summary: Learn about TiDB Data Migration documentation.
 
 > **Note:**
 >
+> - Since DM v5.4, the TiDB Data Migration documentation has been merged into the TiDB documentation of the same version. To read the DM documentation of v5.4 or a later version, go to the [TiDB Documentation](https://docs.pingcap.com/zh/tidb/stable/dm-overview) of the same version.
 > - Since October 2021, DM's GitHub repository has been moved to [pingcap/tiflow](https://github.com/pingcap/tiflow/tree/master/dm). If you see any issues with DM, submit your issue to the `pingcap/tiflow` repository for feedback.
 > - In earlier versions (v1.0 and v2.0), DM uses version numbers that are independent of TiDB. Since v5.3, DM uses the same version number as TiDB. The next version of DM v2.0 is DM v5.3. There are no compatibility changes from DM v2.0 to v5.3, and the upgrade process is no different from a normal upgrade, only an increase in version number.
 

--- a/zh/_index.md
+++ b/zh/_index.md
@@ -9,6 +9,7 @@ summary: 了解 TiDB Data Migration 用户文档。
 
 > **注意：**
 >
+> - 从 DM v5.4 起，TiDB Data Migration 的用户文档已合并入相同版本号的 TiDB 文档。如需阅读 v5.4 及之后版本的 DM 文档，请访问对应版本的 [TiDB 文档](https://docs.pingcap.com/zh/tidb/stable/dm-overview)。
 > - DM 的 GitHub 代码仓库已于 2021 年 12 月迁移到 [pingcap/tiflow](https://github.com/pingcap/tiflow/tree/master/dm)。如有任何关于 DM 的问题，请在 `pingcap/tiflow` 仓库提交，以获得后续反馈。
 > - 在较早版本中（v1.0 和 v2.0），DM 采用独立于 TiDB 的版本号。从 DM v5.3 起，DM 采用与 TiDB 相同的版本号。DM v2.0 的下一个版本为 DM v5.3。DM v2.0 到 v5.3 无兼容性变更，升级过程与正常升级无差异，仅仅是版本号上的增加。
 


### PR DESCRIPTION

### What is changed, added, or deleted? (Required)

This PR tells users to go to TiDB documentation site to read DM documentation. 

### Which DM version(s) do your changes apply to? (Required)

<!-- You **must** choose the DM version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

Since December 23, 2021, the TiDB DM documentation in the master branch has been merged to TiDB documentation by [#8042](https://github.com/pingcap/docs-cn/pull/8042) and [#7317](https://github.com/pingcap/docs/pull/7317). To create a PR for TiDB DM versions later than v5.3, either go to TiDB [English documentation repository](https://github.com/pingcap/docs) or [Chinese documentation repository](https://github.com/pingcap/docs-cn).

- [x] v5.3 (TiDB DM 5.3 versions)
- [ ] v2.0 (TiDB DM 2.0 versions)
- [ ] v1.0 (TiDB DM 1.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
